### PR TITLE
Fix undefined variable 'tik' for non-API mode

### DIFF
--- a/webui/omni_gradio.py
+++ b/webui/omni_gradio.py
@@ -50,6 +50,7 @@ def process_audio(audio):
                 except Exception as e:
                     print(f"error: {e}")
     else:
+        tik = time.time()
         for chunk in omni_client.run_AT_batch_stream(filepath):
             # Convert chunk to numpy array
             if cnt == 0:


### PR DESCRIPTION
Hi there,

Running without `API_URL`, it seems `omni_gradio.py` will load the model at current runtime directly, but it shows following error:

```
UnboundLocalError: local variable 'tik' referenced before assignment 
```

This PR fix this.