### PR TITLE
Make download stats work

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -15,7 +15,7 @@ from typing_extensions import Self
 from litgpt.config import Config
 
 
-class GPT(nn.Module):
+class GPT(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/gpt-omni/mini-omni", pipeline_tag="text-to-speech", license="mit"):
     def __init__(self, config: Config) -> None:
         super().__init__()
         assert config.padded_vocab_size is not None


### PR DESCRIPTION
Hi @mini-omni,

Thanks for this nice work! 

I noticed you already use the 🤗 hub for loading the model, which is great! 

This PR aims to improve the integration by:

* adding `from_pretrained` and `push_to_hub`capabilities to the `GPT` model
* making sure download numbers work for your model (similar to models in the Transformers library)

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from litgpt.model import GPT

# define model
model = GPT(...)

# equip with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("gpt-omni/mini-omni")

# reload
model = GPT.from_pretrained("gpt-omni/mini-omni")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub.

Would you be interested in this integration?

Kind regards,

Niels